### PR TITLE
Add script API functions and identifiers

### DIFF
--- a/output.js
+++ b/output.js
@@ -40,6 +40,65 @@ module.exports = function* menu(_interpreter) {
         a: 1
     }]), tb.start = Date.now(), tb.hiding = false, tb;
 
+    ({
+        x: _interpreter.renderer.width * 50 * 0.01,
+        y: _interpreter.renderer.height * 50 * 0.01,
+        cx: {
+            _type: 'computed',
+            unit: 'aw',
+            value: 50
+        },
+        cy: {
+            _type: 'computed',
+            unit: 'ah',
+            value: 50
+        }
+    });
+    ({
+        x: _interpreter.renderer.width * 0 * 0.01,
+        y: _interpreter.renderer.height * 100 * 0.01,
+        cx: {
+            _type: 'computed',
+            unit: 'aw',
+            value: 100
+        },
+        cy: {
+            _type: 'computed',
+            unit: 'ah',
+            value: 100
+        }
+    });
+    ({
+        x: _interpreter.renderer.width * 100 * 0.01,
+        y: _interpreter.renderer.height * 100 * 0.01,
+        cx: {
+            _type: 'computed',
+            unit: 'aw',
+            value: 0
+        },
+        cy: {
+            _type: 'computed',
+            unit: 'ah',
+            value: 100
+        }
+    });
+    ({
+        a: 0.75,
+        cy: {
+            _type: 'computed',
+            unit: 'ah',
+            value: 90
+        }
+    });
+    ({
+        a: 1,
+        cy: {
+            _type: 'computed',
+            unit: 'ah',
+            value: 100
+        }
+    });
+
     _cache = [Aya || "", `Hello`], _interpreter.tb.speaker = _cache[0].hasOwnProperty('name') ? _cache[0].name : _cache[0], _interpreter.tb.speakerColor = _cache[0].hasOwnProperty('color') ? _cache[0].color : _interpreter.theme.defaultSpeakerColor, _interpreter.tb.text = _cache[1].toString(), _interpreter.tb.textIndex = 0, yield ['pause', void 0], _cache[0];
     void 0;
 };

--- a/plugin/all/func.duration.js
+++ b/plugin/all/func.duration.js
@@ -1,0 +1,15 @@
+let types = require('babel-types');
+let template = require('babel-template');
+
+let awTemplate = template(`
+  ({ duration: VALUE })
+`)
+module.exports = (path, state, plugin, args) => {
+  return path.replaceWith(
+    awTemplate(
+      Object.assign({
+        VALUE: args[0]
+      }, plugin.identifiers)
+    ).expression
+  )
+};

--- a/plugin/all/func.ease.js
+++ b/plugin/all/func.ease.js
@@ -1,0 +1,15 @@
+let types = require('babel-types');
+let template = require('babel-template');
+
+let awTemplate = template(`
+  ({ ease: VALUE })
+`)
+module.exports = (path, state, plugin, args) => {
+  return path.replaceWith(
+    awTemplate(
+      Object.assign({
+        VALUE: args[0]
+      }, plugin.identifiers)
+    ).expression
+  )
+};

--- a/plugin/all/id.absoluteCenter.js
+++ b/plugin/all/id.absoluteCenter.js
@@ -1,0 +1,18 @@
+let types = require('babel-types');
+let template = require('babel-template');
+
+let queueTemplate = template(`
+  !({
+    x: vw(50),
+    y: vh(50),
+    cx: aw(50),
+    cy: ah(50)
+  })
+`)
+module.exports = (path, state, plugin, args) => {
+  return path.replaceWith(
+    queueTemplate(
+      Object.assign({}, plugin.identifiers)
+    ).expression.argument
+  )
+};

--- a/plugin/all/id.active.js
+++ b/plugin/all/id.active.js
@@ -1,0 +1,16 @@
+let types = require('babel-types');
+let template = require('babel-template');
+
+let queueTemplate = template(`
+  !({
+    a: 1,
+    cy: ah(100)
+  })
+`)
+module.exports = (path, state, plugin, args) => {
+  return path.replaceWith(
+    queueTemplate(
+      Object.assign({}, plugin.identifiers)
+    ).expression.argument
+  )
+};

--- a/plugin/all/id.inactive.js
+++ b/plugin/all/id.inactive.js
@@ -1,0 +1,16 @@
+let types = require('babel-types');
+let template = require('babel-template');
+
+let queueTemplate = template(`
+  !({
+    a: 0.75,
+    cy: ah(90)
+  })
+`)
+module.exports = (path, state, plugin, args) => {
+  return path.replaceWith(
+    queueTemplate(
+      Object.assign({}, plugin.identifiers)
+    ).expression.argument
+  )
+};

--- a/plugin/all/id.stageLeft.js
+++ b/plugin/all/id.stageLeft.js
@@ -1,0 +1,18 @@
+let types = require('babel-types');
+let template = require('babel-template');
+
+let queueTemplate = template(`
+  !({
+    x: vw(0),
+    y: vh(100),
+    cx: aw(100),
+    cy: ah(100)
+  })
+`)
+module.exports = (path, state, plugin, args) => {
+  return path.replaceWith(
+    queueTemplate(
+      Object.assign({}, plugin.identifiers)
+    ).expression.argument
+  )
+};

--- a/plugin/all/id.stageRight.js
+++ b/plugin/all/id.stageRight.js
@@ -1,0 +1,18 @@
+let types = require('babel-types');
+let template = require('babel-template');
+
+let queueTemplate = template(`
+  !({
+    x: vw(100),
+    y: vh(100),
+    cx: aw(0),
+    cy: ah(100)
+  })
+`)
+module.exports = (path, state, plugin, args) => {
+  return path.replaceWith(
+    queueTemplate(
+      Object.assign({}, plugin.identifiers)
+    ).expression.argument
+  )
+};

--- a/story/main.js
+++ b/story/main.js
@@ -10,6 +10,12 @@ let Aya = Character({
 
 show(bg, visible);
 show(Aya, visible);
-show(tb, visible)
+show(tb, visible);
+
+absoluteCenter;
+stageLeft;
+stageRight;
+inactive;
+active;
 
 Aya`Hello`;


### PR DESCRIPTION
This adds support for:
- `absoluteCenter`
- `active`
- `inactive`
- `stageLeft`
- `stageRight`
- `ease('type')`
- `duration(ms)`
